### PR TITLE
join yelp and hygiene data

### DIFF
--- a/yh_join.js
+++ b/yh_join.js
@@ -1,0 +1,21 @@
+conn = new Mongo();
+db = conn.getDB("weisheng");
+db.yelpDataMain.find().forEach(
+  function(e) {
+    e.name = e.name.toUpperCase();
+    db.yelpDataMain.save(e);
+  }
+);
+db.hygiene.aggregate([
+        {
+                $lookup:
+                {
+                        from:"yelpDataMain",
+                        localField:"DBA",
+                        foreignField:"name",
+                        as:"yelp"
+                }
+        },
+        {       $out:"yelp_hygiene"}
+]);
+


### PR DESCRIPTION
yh_join.js is used to join the hygiene data with yelp data, you can run it in mongo shell by type load("//the address of yh_join.js"). Because in the hygiene dataset, the name are all capital letters, but yelp has capital letters and small letters, so I change all the name in yelp to capitals, then use lookup to join them. I made a test, the time of transfer small letters to capital letters is not long, maybe about 1 minute. But the join operation spend a lot of time.
