### PR TITLE
This shell scipt is used to import hygiene data to mongodb

### DIFF
--- a/import_data.sh
+++ b/import_data.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mongoimport --db weisheng --collection hygiene --type csv --headerline --file /home/leo/Downloads/DOHMH_New_York_City_Restaurant_Inspection_Results.csv


### PR DESCRIPTION
Before using it, you need to go to select Properties --> Select Permissions -->Select Allow executing file as a program. Then go to terminal and type ./import_data.sh.